### PR TITLE
Try to solve duplicate conn bug

### DIFF
--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -147,7 +147,7 @@ func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error
 	if err != nil {
 		return err
 	}
-	logging.Info("COOL?", addr, pi)
+
 	err = pdb.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(peersLabel)
 
@@ -161,7 +161,7 @@ func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error
 	if err != nil {
 		return err
 	}
-	logging.Info("UPDATE DONE")
+
 	return nil
 
 }

--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -147,7 +147,7 @@ func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error
 	if err != nil {
 		return err
 	}
-
+	logging.Info("COOL?", addr, pi)
 	err = pdb.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(peersLabel)
 
@@ -161,7 +161,7 @@ func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error
 	if err != nil {
 		return err
 	}
-
+	logging.Info("UPDATE DONE")
 	return nil
 
 }


### PR DESCRIPTION
We still go ahead with the committing process even if we already have it in memory. There's no reason we must accept multiple connections from the same peer, so we can safely error out.