### PR TITLE
Simplify lnp2p connections a bit more

### DIFF
--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -318,14 +318,6 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		displayAllCommands = true
 	}
 
-	// Balance reply needed for bals and chans
-	if cmd == "chans" || cmd == "bals" || displayAllCommands {
-		err := lc.Call("LitRPC.Balance", nil, bReply)
-		if err != nil {
-			return err
-		}
-	}
-
 	if cmd == "conns" || displayAllCommands {
 		err := lc.Call("LitRPC.ListConnections", nil, pReply)
 		if err != nil {
@@ -343,28 +335,20 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		}
 	}
 
-	err = lc.Call("LitRPC.Balance", nil, bReply)
-	if err != nil {
-		return err
-	}
-
-	walHeights := map[uint32]int32{}
-	for _, b := range bReply.Balances {
-		walHeights[b.CoinType] = b.SyncHeight
-	}
-
-	err = lc.Call("LitRPC.ChannelList", nil, cReply)
-	if err != nil {
-		return err
-	}
-	if len(cReply.Channels) > 0 {
-		fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Channels:"))
-	}
-
 	if cmd == "chans" || displayAllCommands {
 		err := lc.Call("LitRPC.ChannelList", nil, cReply)
 		if err != nil {
 			return err
+		}
+
+		err = lc.Call("LitRPC.Balance", nil, bReply)
+		if err != nil {
+			return err
+		}
+
+		walHeights := map[uint32]int32{}
+		for _, b := range bReply.Balances {
+			walHeights[b.CoinType] = b.SyncHeight
 		}
 
 		if len(cReply.Channels) > 0 {
@@ -553,6 +537,11 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	}
 
 	if cmd == "bals" || displayAllCommands {
+		err = lc.Call("LitRPC.Balance", nil, bReply)
+		if err != nil {
+			return err
+		}
+
 		if len(bReply.Balances) > 0 {
 			if displayAllCommands {
 				fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Balances:"))

--- a/cmd/lit-af/shell.go
+++ b/cmd/lit-af/shell.go
@@ -318,6 +318,13 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 		displayAllCommands = true
 	}
 
+	if cmd == "chans" || cmd == "bals" {
+		err = lc.Call("LitRPC.Balance", nil, bReply)
+		if err != nil {
+			return err
+		}
+	}
+
 	if cmd == "conns" || displayAllCommands {
 		err := lc.Call("LitRPC.ListConnections", nil, pReply)
 		if err != nil {
@@ -337,11 +344,6 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 
 	if cmd == "chans" || displayAllCommands {
 		err := lc.Call("LitRPC.ChannelList", nil, cReply)
-		if err != nil {
-			return err
-		}
-
-		err = lc.Call("LitRPC.Balance", nil, bReply)
 		if err != nil {
 			return err
 		}
@@ -537,11 +539,6 @@ func (lc *litAfClient) Ls(textArgs []string) error {
 	}
 
 	if cmd == "bals" || displayAllCommands {
-		err = lc.Call("LitRPC.Balance", nil, bReply)
-		if err != nil {
-			return err
-		}
-
 		if len(bReply.Balances) > 0 {
 			if displayAllCommands {
 				fmt.Fprintf(color.Output, "\t%s\n", lnutil.Header("Balances:"))

--- a/db/lnbolt/peerdb.go
+++ b/db/lnbolt/peerdb.go
@@ -134,10 +134,6 @@ func (pdb *peerboltdb) GetPeerInfos() (map[lncore.LnAddr]lncore.PeerInfo, error)
 
 }
 
-func (pdb *peerboltdb) AddPeer(addr lncore.LnAddr, pi lncore.PeerInfo) error {
-	return pdb.UpdatePeer(addr, &pi)
-}
-
 func (pdb *peerboltdb) UpdatePeer(addr lncore.LnAddr, pi *lncore.PeerInfo) error {
 
 	var err error

--- a/lncore/peers.go
+++ b/lncore/peers.go
@@ -9,7 +9,6 @@ type LitPeerStorage interface {
 	GetPeerAddrs() ([]LnAddr, error)
 	GetPeerInfo(addr LnAddr) (*PeerInfo, error)
 	GetPeerInfos() (map[LnAddr]PeerInfo, error)
-	AddPeer(addr LnAddr, pi PeerInfo) error
 	UpdatePeer(addr LnAddr, pi *PeerInfo) error
 	DeletePeer(addr LnAddr) error
 

--- a/lnp2p/listen.go
+++ b/lnp2p/listen.go
@@ -52,45 +52,45 @@ func acceptConnections(listener *lndc.Listener, port int, pm *PeerManager) {
 
 		// Create the actual peer object since we need to interface with db to do this
 		// TODO: remove this
-		newPeer := &Peer{
+		remotePeer := &Peer{
 			lnaddr:   remoteLitAddr,
 			nickname: nil,
 			conn:     lndcConn,
 			idpubkey: remotePubkey,
-			idx: nil,
+			idx:      nil,
 		}
 
 		// Read the peer info from the DB.
-		pi, err := pm.peerdb.GetPeerInfo(remoteLitAddr) // search based on remote peer address
+		remotePeerInfo, err := pm.peerdb.GetPeerInfo(remoteLitAddr) // search based on remote peer address
 		if err != nil {
 			logging.Warnf("problem loading peer info in DB: %s\n", err.Error())
 			netConn.Close()
 			continue
 		}
 
-		if pi != nil {
-			// we already have this peer in the db, but we want to udpate this
-			// the update method is a bit weird, so we delete it directly and
-			// replacing it with a new one.
-			// TODO: Fix the UpdatePeer method to behave as expected
-			logging.Info("Found peer in peerdb. Don't disconnect, just delete", pi.PeerIdx)
-			newPeer.idx = &pi.PeerIdx
-			pm.peerdb.DeletePeer(remoteLitAddr)
+		if remotePeerInfo != nil {
+			logging.Debugf("Found peer in peerdb. Don't disconnect, just delete: %d, %s, %s", remotePeerInfo.PeerIdx, *remotePeerInfo.NetAddr, remoteNetAddr)
+			// the only thing that can change here is the netAddr since we want the
+			// idx to stay the same. However, we need to register the peer again
+			// so that it goes into the peer map we have on disk
+			remotePeerInfo.NetAddr = &remoteNetAddr
+			remotePeer.idx = &remotePeerInfo.PeerIdx
 		} else {
+			logging.Debug("Didn't find peer in peerdb. Creating RPInfo and committing it to the db")
+			// remotePeerInfo is nil, so we need one
+			remotePeerInfo = &lncore.PeerInfo{
+				LnAddr:   &remoteLitAddr,
+				Nickname: nil,
+				NetAddr:  &remoteNetAddr,
+			}
+
 			temp, err := pm.peerdb.GetUniquePeerIdx()
 			if err != nil {
 				logging.Errorf("problem getting unique peeridx: %s\n", err.Error())
 			}
-			newPeer.idx = &temp
+			remotePeer.idx = &temp
 		}
-
-		pi = &lncore.PeerInfo{
-			LnAddr:   &remoteLitAddr,
-			Nickname: nil,
-			NetAddr:  &remoteNetAddr,
-			PeerIdx:  *newPeer.idx,
-		}
-		err = pm.peerdb.AddPeer(remoteLitAddr, *pi)
+		err = pm.peerdb.UpdatePeer(remoteLitAddr, remotePeerInfo)
 		if err != nil {
 			// don't close it, I guess
 			logging.Errorf("problem saving peer info to DB: %s\n", err.Error())
@@ -98,10 +98,10 @@ func acceptConnections(listener *lndc.Listener, port int, pm *PeerManager) {
 
 		// Don't do any locking here since registerPeer takes a lock and Go's
 		// mutex isn't reentrant.
-		pm.registerPeer(newPeer)
+		pm.registerPeer(remotePeer)
 
 		// Start a goroutine to process inbound traffic for this peer.
-		go processConnectionInboundTraffic(newPeer, pm)
+		go processConnectionInboundTraffic(remotePeer, pm)
 	}
 
 	// Update the stop reason.

--- a/lnp2p/peermgr.go
+++ b/lnp2p/peermgr.go
@@ -252,7 +252,7 @@ func (pm *PeerManager) tryConnectPeer(netaddr string, lnaddr *lncore.LnAddr, set
 			PeerIdx:  pidx,
 		}
 		logging.Infof("peermgr: Registering peer %s\n", p.GetLnAddr())
-		err = pm.peerdb.AddPeer(p.GetLnAddr(), *pi)
+		err = pm.peerdb.UpdatePeer(p.GetLnAddr(), pi)
 		if err != nil {
 			logging.Errorf("peermgr: Error saving new peer to DB: %s\n", err.Error())
 		}

--- a/qln/lndb.go
+++ b/qln/lndb.go
@@ -362,7 +362,7 @@ func (nd *LitNode) SaveNicknameForPeerIdx(nickname string, idx uint32) error {
 
 	// Actually go and set it.
 	pi := peer.IntoPeerInfo()
-	err := nd.NewLitDB.GetPeerDB().AddPeer(peer.GetLnAddr(), pi)
+	err := nd.NewLitDB.GetPeerDB().UpdatePeer(peer.GetLnAddr(), &pi)
 
 	return err // same as if err != nil { return err } ; return nil
 }


### PR DESCRIPTION
Remove UpdatePeer's alias function and update some lit-af stuff. This shouldn't affect the admin panel's calls, but reduces `ls` calls from remote `lit-af`'s by half.